### PR TITLE
Lib bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <scalaj.version>2.3.0</scalaj.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.4.0</dans-scala-lib.version>
+        <better-files.version>3.4.0</better-files.version>
 
         <!-- Logging -->
         <logback.version>1.2.3</logback.version>
@@ -138,6 +139,11 @@
                 <groupId>nl.knaw.dans.lib</groupId>
                 <artifactId>dans-scala-lib_2.12</artifactId>
                 <version>${dans-scala-lib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.pathikrit</groupId>
+                <artifactId>better-files_2.12</artifactId>
+                <version>${better-files.version}</version>
             </dependency>
 
             <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </description>
     <properties>
         <!-- Scala -->
-        <scallop.version>3.1.1</scallop.version>
+        <scallop.version>3.1.2</scallop.version>
         <scalarx.version>0.26.5</scalarx.version>
         <scala-xml.version>1.1.0</scala-xml.version>
         <scalaj.version>2.3.0</scalaj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- HTTP server support -->
         <!-- We cannot use the newest 9.x version because of issues when proxing to it from Apache HTTP Server -->
         <jetty.version>8.2.0.v20160908</jetty.version>
-        <scalatra.version>2.6.2</scalatra.version>
+        <scalatra.version>2.6.3</scalatra.version>
 
         <!-- Database connectivity -->
         <postgresql.version>9.4-1205-jdbc42</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- Scala -->
         <scallop.version>3.1.1</scallop.version>
         <scalarx.version>0.26.5</scalarx.version>
-        <scala-xml.version>1.0.6</scala-xml.version>
+        <scala-xml.version>1.1.0</scala-xml.version>
         <scalaj.version>2.3.0</scalaj.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.4.0</dans-scala-lib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <scala-test.version>3.0.5</scala-test.version>
         <scalamock.version>4.1.0</scalamock.version>
-        <scalacheck.version>1.13.5</scalacheck.version>
+        <scalacheck.version>1.14.0</scalacheck.version>
 
         <!-- LEGACY -->
         <spring.version>4.0.2.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <easymock.version>3.1</easymock.version>
         <powermock.version>1.6.2</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <scala-test.version>3.0.4</scala-test.version>
+        <scala-test.version>3.0.5</scala-test.version>
         <scalamock.version>3.6.0</scalamock.version>
         <scalacheck.version>1.13.5</scalacheck.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <powermock.version>1.6.2</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
         <scala-test.version>3.0.5</scala-test.version>
-        <scalamock.version>3.6.0</scalamock.version>
+        <scalamock.version>4.1.0</scalamock.version>
         <scalacheck.version>1.13.5</scalacheck.version>
 
         <!-- LEGACY -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <scallop.version>3.1.2</scallop.version>
         <scalarx.version>0.26.5</scalarx.version>
         <scala-xml.version>1.1.0</scala-xml.version>
-        <scalaj.version>2.3.0</scalaj.version>
+        <scalaj.version>2.4.0</scalaj.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.4.0</dans-scala-lib.version>
         <better-files.version>3.4.0</better-files.version>


### PR DESCRIPTION
Version bumps for various Scala-related libraries. As far as I can tell from the diffs I've seen, there are no breaking changes. Besides, I added `better-files` as a dependency in this list.

@DANS-KNAW/easy for review

@janvanmansum I'm not sure what the release process of these parent projects is, these days. Hopefully you got some kind of script to apply this PR to all projects?