### PR TITLE
fix artifact name of scalamock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
             </dependency>
             <dependency>
                 <groupId>org.scalamock</groupId>
-                <artifactId>scalamock-scalatest-support_2.12</artifactId>
+                <artifactId>scalamock_2.12</artifactId>
                 <version>${scalamock.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
@DANS-KNAW/easy for review

@janvanmansum you were right that #1 didn't work... An artifact name was changed from `scalamock-scalatest-support_2.12` to `scalamock`. That's why integrating #1 didn't work.